### PR TITLE
Fix crash on iOS after attempt to login with user that don't have bitmoji set

### DIFF
--- a/ios/SnapchatLogin.m
+++ b/ios/SnapchatLogin.m
@@ -63,10 +63,12 @@ RCT_REMAP_METHOD(fetchUserData,
             NSDictionary *data = resources[@"data"];
             NSDictionary *me = data[@"me"];
             NSDictionary *bitmoji = me[@"bitmoji"];
+            NSString *bitmojiAvatarUrl = bitmoji[@"avatar"];
+            if (bitmojiAvatarUrl == (id)[NSNull null] || bitmojiAvatarUrl.length == 0 ) bitmojiAvatarUrl = @"(null)";
             resolve(@{
                 @"displayName": me[@"displayName"],
                 @"externalId": me[@"externalId"],
-                @"avatar": bitmoji[@"avatar"]
+                @"avatar": bitmojiAvatarUrl
             });
             
         }


### PR DESCRIPTION
Return "(null)" string as avatar if no bitmoji is set.